### PR TITLE
Install Pundit as authorization system.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ group :development do
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "pundit", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     pg (1.2.3)
     puma (5.5.2)
       nio4r (~> 2.0)
+    pundit (2.1.1)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -197,6 +199,7 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)
+  pundit (~> 2.1)
   rails!
   sass-rails (>= 6)
   standard

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(request.referrer || root_path)
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end


### PR DESCRIPTION
This will help us standardize our approach to authorization within the application. We'll need to make sure we're rendering a flash message within the application, otherwise users won't see a warning when the're redirected from an endpoint they do not have access to.

I deliberately did not [enable policies and scopes everywhere](https://github.com/varvet/pundit#ensuring-policies-and-scopes-are-used), but we might want to consider this if the app requires a user to be subscribed to have access.

**Other Notes**

- Pundit can help with [scopes](https://github.com/varvet/pundit#scopes)
- Pundit can help with [strong params](https://github.com/varvet/pundit#strong-parameters)