### PR TITLE
feat: Show message UI element based on auth

### DIFF
--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -15,13 +15,14 @@
             <%= @developer.hero %>
           </h2>
         </div>
-
-        <div class="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
-          <button type="button" class="inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
-            <%= icon "solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
-            <span>Message</span>
-          </button>
-        </div>
+        <% if user_signed_in? %>
+          <div data-behavior="message-button" class="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
+            <button type="button" class="inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+              <%= icon "solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
+              <span>Message</span>
+            </button>
+          </div>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -15,12 +15,13 @@
             <%= @developer.hero %>
           </h2>
         </div>
+
         <% if user_signed_in? %>
-          <div data-behavior="message-button" class="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
-            <button type="button" class="inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+          <div class="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
+            <%= link_to "mailto:#{@developer.email}", data: { behavior: "message-button" }, class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
               <%= icon "solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
               <span>Message</span>
-            </button>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,34 @@ ActiveRecord::Schema.define(version: 2021_10_29_162317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "developers", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -46,4 +74,6 @@ ActiveRecord::Schema.define(version: 2021_10_29_162317) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -11,16 +11,19 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_select "h2", two.hero
   end
 
-  test "can see send message button if logged in" do
-    one = developers(:one)
-    get developer_path(one)
-
-    assert_select('div[data-behavior="message-button"]', count: 0)
-
+  test "can see send message button if signed in" do
     sign_in users(:one)
-    get developer_path(one)
+    developer = developers(:one)
 
-    assert_select('div[data-behavior="message-button"]')
+    get developer_path(developers(:one))
+
+    assert_select "a[href=?]", "mailto:#{developer.email}"
+  end
+
+  test "send message button is hidden if not signed in" do
+    developer = developers(:one)
+    get developer_path(developers(:one))
+    assert_select "a[href=?]", "mailto:#{developer.email}", false
   end
 
   test "successful profile creation" do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -11,6 +11,18 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_select "h2", two.hero
   end
 
+  test "can see send message button if logged in" do
+    one = developers(:one)
+    get developer_path(one)
+
+    assert_select('div[data-behavior="message-button"]', count: 0)
+
+    sign_in users(:one)
+    get developer_path(one)
+
+    assert_select('div[data-behavior="message-button"]')
+  end
+
   test "successful profile creation" do
     sign_in users(:one)
 


### PR DESCRIPTION
Resolves #8

For now this just adds the UI functionality for authorizing users before showing the message button. In the future obviously we will need to authorize the actual controller actions that go into that feature.

Additionally for now, this is tested using a controller test. Given #18, we might want to install the `view_component` gem. It'll help us extract out common UI patterns, and it'll make it faster to test UI elements like this in the fast. I don't have too much experience with the gem, but I hear that's the main benefit.