### PR TITLE
Add ToastMessageComponent with tests

### DIFF
--- a/app/components/component_with_icon.rb
+++ b/app/components/component_with_icon.rb
@@ -1,0 +1,7 @@
+module ComponentWithIcon
+  def icon_path(icon:)
+    return unless icon.present?
+
+    "icons/solid/#{icon}.svg"
+  end
+end

--- a/app/components/toast_message_component.html.erb
+++ b/app/components/toast_message_component.html.erb
@@ -1,15 +1,15 @@
-<div class="sm:rounded-md shadow-sm p-4 mb-8 bg-<%=- @color %>-50">
+<div class="sm:rounded-md shadow-sm p-4 mb-8 <%= background_classes %>">
   <div class="flex">
     <div class="flex-shrink-0">
-      <%= inline_svg_tag icon_path(icon: @icon), class: "h-5 w-5 text-#{@color}-400" %>
+    <%= inline_svg_tag icon_path(icon: @icon), class: "h-5 w-5 #{icon_classes}" %>
     </div>
 
     <div class="ml-3">
       <% if title.present? %>
-        <h3 class="text-sm font-medium text-<%=- @color %>-800"><%= title %></h3>
+        <h3 class="text-sm font-medium <%= title_classes %>"><%= title %></h3>
       <% end %>
 
-      <div class=" text-sm flex-1 md:flex md:justify-between text-<%=- @color %>-700">
+      <div class=" text-sm flex-1 md:flex md:justify-between">
         <%= content_tag(@messages_tag, role: "list", class: "list-disc space-y-1 #{messages_classes}") do %>
           <% messages.each do |message| %><%= message %><% end %>
         <% end %>

--- a/app/components/toast_message_component.html.erb
+++ b/app/components/toast_message_component.html.erb
@@ -1,0 +1,19 @@
+<div class="sm:rounded-md shadow-sm p-4 mb-8 bg-<%=- @color %>-50">
+  <div class="flex">
+    <div class="flex-shrink-0">
+      <%= inline_svg_tag icon_path(icon: @icon), class: "h-5 w-5 text-#{@color}-400" %>
+    </div>
+
+    <div class="ml-3">
+      <% if title.present? %>
+        <h3 class="text-sm font-medium text-<%=- @color %>-800"><%= title %></h3>
+      <% end %>
+
+      <div class=" text-sm flex-1 md:flex md:justify-between text-<%=- @color %>-700">
+        <%= content_tag(@messages_tag, role: "list", class: "list-disc space-y-1 #{messages_classes}") do %>
+          <% messages.each do |message| %><%= message %><% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/toast_message_component.html.erb
+++ b/app/components/toast_message_component.html.erb
@@ -1,7 +1,7 @@
 <div class="sm:rounded-md shadow-sm p-4 mb-8 <%= background_classes %>">
   <div class="flex">
     <div class="flex-shrink-0">
-    <%= inline_svg_tag icon_path(icon: @icon), class: "h-5 w-5 #{icon_classes}" %>
+      <%= inline_svg_tag icon_path(icon: @icon), class: "h-5 w-5 #{icon_classes}" %>
     </div>
 
     <div class="ml-3">

--- a/app/components/toast_message_component.rb
+++ b/app/components/toast_message_component.rb
@@ -1,0 +1,16 @@
+class ToastMessageComponent < ViewComponent::Base
+  include ComponentWithIcon
+
+  renders_one :title
+  renders_many :messages
+
+  def initialize(icon:, color: "blue", messages_tag: :div)
+    @icon = icon
+    @color = color
+    @messages_tag = messages_tag
+  end
+
+  def messages_classes
+    "mt-2 pl-5" unless @messages_tag == :div
+  end
+end

--- a/app/components/toast_message_component.rb
+++ b/app/components/toast_message_component.rb
@@ -14,7 +14,7 @@ class ToastMessageComponent < ViewComponent::Base
       title: "text-red-800",
       message: "text-red-700"
     }
-  }
+  }.freeze
 
   renders_one :title
   renders_many :messages

--- a/app/components/toast_message_component.rb
+++ b/app/components/toast_message_component.rb
@@ -1,16 +1,50 @@
 class ToastMessageComponent < ViewComponent::Base
   include ComponentWithIcon
 
+  NAMED_STYLES = {
+    blue: {
+      bg: "bg-blue-50",
+      icon: "text-blue-400",
+      title: "text-blue-800",
+      message: "text-blue-700"
+    },
+    red: {
+      bg: "bg-red-50",
+      icon: "text-red-400",
+      title: "text-red-800",
+      message: "text-red-700"
+    }
+  }
+
   renders_one :title
   renders_many :messages
 
-  def initialize(icon:, color: "blue", messages_tag: :div)
+  def initialize(icon:, color: :blue, messages_tag: :div)
     @icon = icon
     @color = color
     @messages_tag = messages_tag
   end
 
+  def color_styles(concern:)
+    NAMED_STYLES.dig(@color, concern) || ""
+  end
+
+  def background_classes
+    color_styles(concern: :bg)
+  end
+
+  def icon_classes
+    color_styles(concern: :icon)
+  end
+
+  def title_classes
+    color_styles(concern: :title)
+  end
+
   def messages_classes
-    "mt-2 pl-5" unless @messages_tag == :div
+    messages_classes = color_styles(concern: :message)
+    messages_classes << " mt-2 pl-5" unless @messages_tag == :div
+
+    messages_classes
   end
 end

--- a/app/components/toast_message_component.rb
+++ b/app/components/toast_message_component.rb
@@ -1,21 +1,6 @@
 class ToastMessageComponent < ViewComponent::Base
   include ComponentWithIcon
 
-  NAMED_STYLES = {
-    blue: {
-      bg: "bg-blue-50",
-      icon: "text-blue-400",
-      title: "text-blue-800",
-      message: "text-blue-700"
-    },
-    red: {
-      bg: "bg-red-50",
-      icon: "text-red-400",
-      title: "text-red-800",
-      message: "text-red-700"
-    }
-  }.freeze
-
   renders_one :title
   renders_many :messages
 
@@ -47,4 +32,21 @@ class ToastMessageComponent < ViewComponent::Base
 
     messages_classes
   end
+
+  private
+
+  NAMED_STYLES = {
+    blue: {
+      bg: "bg-blue-50",
+      icon: "text-blue-400",
+      title: "text-blue-800",
+      message: "text-blue-700"
+    },
+    red: {
+      bg: "bg-red-50",
+      icon: "text-red-400",
+      title: "text-red-800",
+      message: "text-red-700"
+    }
+  }.freeze
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,25 +1,15 @@
 <% if resource.errors.any? %>
   <% content_for :flash do %>
-    <div class="sm:rounded-md bg-red-50 p-4 mb-8">
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <%= inline_svg_tag "icons/solid/x_circle.svg", class: "h-5 w-5 text-red-400" %>
-        </div>
+    <%= render ToastMessageComponent.new(icon: "x_circle", color: "red", messages_tag: :ul) do |c| %>
+      <%= c.title do %>
+        <%= I18n.t "errors.messages.not_saved", count: resource.errors.count, resource: resource.class.model_name.human.downcase %>
+      <% end %>
 
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">
-            <%= I18n.t "errors.messages.not_saved", count: resource.errors.count, resource: resource.class.model_name.human.downcase %>
-          </h3>
-
-          <div class="mt-2 text-sm text-red-700">
-            <ul role="list" class="list-disc pl-5 space-y-1">
-              <% resource.errors.each do |error| %>
-                <li><%= error.full_message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
+      <% resource.errors.each do |error| %>
+        <% c.message do %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if resource.errors.any? %>
   <% content_for :flash do %>
-    <%= render ToastMessageComponent.new(icon: "x_circle", color: "red", messages_tag: :ul) do |c| %>
+    <%= render ToastMessageComponent.new(icon: "x_circle", color: :red, messages_tag: :ul) do |c| %>
       <%= c.title do %>
         <%= I18n.t "errors.messages.not_saved", count: resource.errors.count, resource: resource.class.model_name.human.downcase %>
       <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if flash.alert.present? %>
-  <%= render ToastMessageComponent.new(icon: "x_circle", color: "red") do |c| %>
+  <%= render ToastMessageComponent.new(icon: "x_circle", color: :red) do |c| %>
     <%= c.message do %> <p><%= flash.alert %></p> <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,29 +1,13 @@
 <% if flash.notice.present? %>
-  <div class="sm:rounded-md shadow-sm bg-blue-50 p-4 mb-8">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <%= inline_svg_tag "icons/solid/information_circle.svg", class: "h-5 w-5 text-blue-400" %>
-      </div>
-
-      <div class="ml-3 flex-1 md:flex md:justify-between">
-        <p class="text-sm text-blue-700"><%= flash.notice %></p>
-      </div>
-    </div>
-  </div>
+  <%= render ToastMessageComponent.new(icon: "information_circle") do |c| %>
+    <%= c.message do %> <p><%= flash.notice %></p> <% end %>
+  <% end %>
 <% end %>
 
 <% if flash.alert.present? %>
-  <div class="sm:rounded-md shadow-sm bg-red-50 p-4 mb-8">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <%= inline_svg_tag "icons/solid/x_circle.svg", class: "h-5 w-5 text-red-400" %>
-      </div>
-
-      <div class="ml-3 flex-1 md:flex md:justify-between">
-        <p class="text-sm text-red-700"><%= flash.alert %></p>
-      </div>
-    </div>
-  </div>
+  <%= render ToastMessageComponent.new(icon: "x_circle", color: "red") do |c| %>
+    <%= c.message do %> <p><%= flash.alert %></p> <% end %>
+  <% end %>
 <% end %>
 
 <%= yield :flash %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
 
   purge: [
     "./app/views/**/*.html.erb",
+    "./app/components/**/*.rb",
     "./app/helpers/**/*.rb",
     "./app/javascript/**/*.js"
   ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ module.exports = {
   purge: [
     "./app/views/**/*.html.erb",
     "./app/components/**/*.rb",
+    "./app/components/**/*.html.erb",
     "./app/helpers/**/*.rb",
     "./app/javascript/**/*.js"
   ],

--- a/test/components/toast_message_component_test.rb
+++ b/test/components/toast_message_component_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ToastMessageComponentTest < ViewComponent::TestCase
+  include ActionView::Helpers::TagHelper
+
+  test "basic toast message with icon" do
+    render_inline(ToastMessageComponent.new(icon: "information_circle")) do |c|
+      c.message { "Operation successful" }
+    end
+
+    expect_to_be_color(color: :blue)
+    assert_no_selector("h3")
+    assert_selector("svg")
+    assert_selector("div", text: "Operation successful")
+  end
+
+  test "error state toast message - color red" do
+    render_inline(ToastMessageComponent.new(icon: "information_circle", color: "red")) do |c|
+      c.message { "Operation successful" }
+    end
+
+    expect_to_be_color(color: :red)
+  end
+
+  test "toast message can show a title" do
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red")) do |c|
+      c.title { "There was 1 error" }
+      c.message { "Missing parameter" }
+    end
+
+    expect_to_be_color(color: :red)
+    assert_selector("h3", text: "There was 1 error")
+    assert_selector("div", text: "Missing parameter")
+  end
+
+  test "toast messages can have multiple messages" do
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red")) do |c|
+      c.title { "There were 2 errors" }
+      c.message { tag.p("Missing name") }
+      c.message { tag.p("Missing email") }
+    end
+
+    expect_to_be_color(color: :red)
+    assert_selector("h3", text: "There were 2 errors")
+    assert_selector("p", text: "Missing name")
+    assert_selector("p", text: "Missing email")
+  end
+
+  test "toast messages can have multiple messages and ask for a different messages container" do
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red", messages_tag: :ul)) do |c|
+      c.title { "There were 3 errors" }
+      c.message { tag.li("Missing name") }
+      c.message { tag.li("Missing email") }
+      c.message { tag.li("Missing photo") }
+    end
+
+    expect_to_be_color(color: :red)
+    assert_selector("h3", text: "There were 3 errors")
+    assert_selector("ul")
+    assert_selector("li", text: "Missing name")
+    assert_selector("li", text: "Missing email")
+    assert_selector("li", text: "Missing photo")
+  end
+
+  def expect_to_be_color(color:)
+    assert_selector(".bg-#{color}-50")
+    assert_selector(".text-#{color}-400")
+    assert_selector(".text-#{color}-700")
+  end
+end

--- a/test/components/toast_message_component_test.rb
+++ b/test/components/toast_message_component_test.rb
@@ -15,7 +15,7 @@ class ToastMessageComponentTest < ViewComponent::TestCase
   end
 
   test "error state toast message - color red" do
-    render_inline(ToastMessageComponent.new(icon: "information_circle", color: "red")) do |c|
+    render_inline(ToastMessageComponent.new(icon: "information_circle", color: :red)) do |c|
       c.message { "Operation successful" }
     end
 
@@ -23,7 +23,7 @@ class ToastMessageComponentTest < ViewComponent::TestCase
   end
 
   test "toast message can show a title" do
-    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red")) do |c|
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: :red)) do |c|
       c.title { "There was 1 error" }
       c.message { "Missing parameter" }
     end
@@ -34,7 +34,7 @@ class ToastMessageComponentTest < ViewComponent::TestCase
   end
 
   test "toast messages can have multiple messages" do
-    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red")) do |c|
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: :red)) do |c|
       c.title { "There were 2 errors" }
       c.message { tag.p("Missing name") }
       c.message { tag.p("Missing email") }
@@ -47,7 +47,7 @@ class ToastMessageComponentTest < ViewComponent::TestCase
   end
 
   test "toast messages can have multiple messages and ask for a different messages container" do
-    render_inline(ToastMessageComponent.new(icon: "x_circle", color: "red", messages_tag: :ul)) do |c|
+    render_inline(ToastMessageComponent.new(icon: "x_circle", color: :red, messages_tag: :ul)) do |c|
       c.title { "There were 3 errors" }
       c.message { tag.li("Missing name") }
       c.message { tag.li("Missing email") }


### PR DESCRIPTION
`ToastMessageComponent` uses the "Slots" feature of View Components to offer flexible display options

## Screenshots
<img width="822" alt="image" src="https://user-images.githubusercontent.com/1904364/140455184-4f5a8e3f-9c76-4329-8cac-ab19b64c6d58.png">

<img width="828" alt="image" src="https://user-images.githubusercontent.com/1904364/140455141-cc265015-1230-4e33-85f9-d8aec9052657.png">

<img width="819" alt="image" src="https://user-images.githubusercontent.com/1904364/140455067-51bc1c2a-7982-4edc-9c9d-fba0d50bd5aa.png">


