### PR TITLE
redirect to profile when user signs in successfully

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,5 @@
+class Users::SessionsController < Devise::SessionsController
+  def after_sign_in_path_for(resource)
+    developer_path resource
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,4 +2,8 @@ class Users::SessionsController < Devise::SessionsController
   def after_sign_in_path_for(resource)
     developer_path resource
   end
+
+  def after_sign_out_path_for(resource)
+    request.referer || root_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,10 @@
 class Users::SessionsController < Devise::SessionsController
   def after_sign_in_path_for(resource)
-    developer_path resource
+    if resource.developer.present?
+      developer_path resource.developer
+    else
+      root_path
+    end
   end
 
   def after_sign_out_path_for(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,10 +1,8 @@
 class Users::SessionsController < Devise::SessionsController
   def after_sign_in_path_for(resource)
-    if resource.developer.present?
-      developer_path resource.developer
-    else
-      root_path
-    end
+    return root_path unless resource.developer
+
+    developer_path resource.developer
   end
 
   def after_sign_out_path_for(resource)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {sessions: "users/sessions"}
 
   resources :developers, except: %i[destroy]
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,6 +1,7 @@
 with_profile_one:
   email: one@example.com
   confirmed_at: <%= DateTime.current %>
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
 
 with_profile_two:
   email: two@example.com
@@ -9,6 +10,7 @@ with_profile_two:
 without_profile:
   email: three@example.com
   confirmed_at: <%= DateTime.current %>
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
 
 admin:
   email: admin@example.com

--- a/test/integration/users/sessions_test.rb
+++ b/test/integration/users/sessions_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class Users::SessionsTest < ActionDispatch::IntegrationTest
   test "it redirects to developer profile if profile is present" do
-    post user_session_path user: { email: users(:with_profile_one).email, password: 'password'}
+    post user_session_path user: {email: users(:with_profile_one).email, password: "password"}
     assert_redirected_to developer_path developers(:one)
   end
 
   test "it redirects to root path when user does not have developer account" do
-    post user_session_path user: { email: users(:without_profile).email, password: 'password'}
+    post user_session_path user: {email: users(:without_profile).email, password: "password"}
     assert_redirected_to root_path
   end
 
@@ -20,7 +20,7 @@ class Users::SessionsTest < ActionDispatch::IntegrationTest
 
   test "it redirects to referrer when logging out if referer is set" do
     sign_in users(:with_profile_one)
-    delete destroy_user_session_path, headers: { "HTTP_REFERER":  developer_path(developers(:one)) }
+    delete destroy_user_session_path, headers: {HTTP_REFERER: developer_path(developers(:one))}
 
     assert_redirected_to developer_path developers(:one)
   end

--- a/test/integration/users/sessions_test.rb
+++ b/test/integration/users/sessions_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Users::SessionsTest < ActionDispatch::IntegrationTest
+  test "it redirects to developer profile if profile is present" do
+    post user_session_path user: { email: users(:with_profile_one).email, password: 'password'}
+    assert_redirected_to developer_path developers(:one)
+  end
+
+  test "it redirects to root path when user does not have developer account" do
+    post user_session_path user: { email: users(:without_profile).email, password: 'password'}
+    assert_redirected_to root_path
+  end
+
+  test "it redirects to root path after log out" do
+    sign_in users(:with_profile_one)
+    delete destroy_user_session_path
+
+    assert_redirected_to root_path
+  end
+
+  test "it redirects to referrer when logging out if referer is set" do
+    sign_in users(:with_profile_one)
+    delete destroy_user_session_path, headers: { "HTTP_REFERER" => developer_path(developers(:one)) }
+
+    assert_redirected_to developer_path developers(:one)
+  end
+end

--- a/test/integration/users/sessions_test.rb
+++ b/test/integration/users/sessions_test.rb
@@ -20,7 +20,7 @@ class Users::SessionsTest < ActionDispatch::IntegrationTest
 
   test "it redirects to referrer when logging out if referer is set" do
     sign_in users(:with_profile_one)
-    delete destroy_user_session_path, headers: { "HTTP_REFERER" => developer_path(developers(:one)) }
+    delete destroy_user_session_path, headers: { "HTTP_REFERER":  developer_path(developers(:one)) }
 
     assert_redirected_to developer_path developers(:one)
   end


### PR DESCRIPTION
closes https://github.com/joemasilotti/railsdevs.io/issues/50.

- fixes issue when the logout button is pressed the redirect to the root path will be a `turbo_stream` so the `index.turbo_stream` will be rendered instead of `index.html`.

Prod: 


https://user-images.githubusercontent.com/38360603/140626242-1de6cd90-abfd-432e-8ae1-e8b051c221e7.mov


Dev: via https://github.com/joemasilotti/railsdevs.io/pull/52/commits/65a08196a44807da9912964db21c619a31b21569


https://user-images.githubusercontent.com/38360603/140626248-0928a057-d365-486e-9bf4-4eb55aaf9018.mov

