### PR TITLE
Style password reset, confirmation and password edit page

### DIFF
--- a/app/components/toast_message_component.html.erb
+++ b/app/components/toast_message_component.html.erb
@@ -9,7 +9,7 @@
         <h3 class="text-sm font-medium <%= title_classes %>"><%= title %></h3>
       <% end %>
 
-      <div class=" text-sm flex-1 md:flex md:justify-between">
+      <div class="text-sm flex-1 md:flex md:justify-between">
         <%= content_tag(@messages_tag, role: "list", class: "list-disc space-y-1 #{messages_classes}") do %>
           <% messages.each do |message| %><%= message %><% end %>
         <% end %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -15,7 +15,7 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="mt-6 bg-white sm:rounded-lg">
-        <%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |f| %>
+        <%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: {class: "space-y-6", data: {turbo: false}} do |f| %>
           <div>
             <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
             <div class="mt-1">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,34 @@
+<%= render "shared/error_messages", resource: resource %>
+
+<div class="flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+  <div class="mx-auto w-full max-w-sm lg:w-96">
+    <h2 class="text-3xl font-extrabold text-gray-900">
+      Resend confirmation instructions
+    </h2>
+
+    <%- if devise_mapping.registerable? %>
+      <p class="mt-2 text-sm text-gray-600">
+        Or
+        <%= link_to "create an account", new_registration_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
+      </p>
+    <% end %>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="mt-6 bg-white sm:rounded-lg">
+        <%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |f| %>
+          <div>
+            <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+            <div class="mt-1">
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            </div>
+          </div>
+
+          <div class="actions">
+            <%= f.submit "Resend confirmation instructions", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,44 @@
+<%= render "shared/error_messages", resource: resource %>
+
+<div class="flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+  <div class="mx-auto w-full max-w-sm lg:w-96">
+    <div>
+      <h2 class="text-3xl font-extrabold text-gray-900">
+        Change your password
+      </h2>
+
+      <%- if devise_mapping.registerable? %>
+        <p class="mt-2 text-sm text-gray-600">
+          Or
+          <%= link_to "create an account", new_registration_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
+        </p>
+      <% end %>
+    </div>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="mt-6 bg-white sm:rounded-lg">
+        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-6", data: { turbo: false } } do |f| %>
+          <%= f.hidden_field :reset_password_token %>
+
+          <div>
+            <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+            <div class="mt-1">
+              <%= f.password_field :password, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            </div>
+          </div>
+
+          <div>
+            <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+            <div class="mt-1">
+              <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            </div>
+          </div>
+
+          <div>
+            <%= f.submit "Change my password", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -17,7 +17,7 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="mt-6 bg-white sm:rounded-lg">
-        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-6", data: { turbo: false } } do |f| %>
+        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: {method: :put, class: "space-y-6", data: {turbo: false}} do |f| %>
           <%= f.hidden_field :reset_password_token %>
 
           <div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,39 @@
+<%= render "shared/error_messages", resource: resource %>
+
+<div class="flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+  <div class="mx-auto w-full max-w-sm lg:w-96">
+    <h2 class="text-3xl font-extrabold text-gray-900">
+      Forgot your password?
+    </h2>
+
+    <%- if devise_mapping.registerable? %>
+      <p class="mt-2 text-sm text-gray-600">
+        Or
+        <%= link_to "create an account", new_registration_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
+      </p>
+    <% end %>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="mt-6 bg-white sm:rounded-lg">
+        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |f| %>
+          <div>
+            <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+            <div class="mt-1">
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            </div>
+          </div>
+
+          <div class="actions">
+            <%= f.submit "Send me reset password instructions", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+          </div>
+
+          <div class="text-sm">
+            <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+              <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -15,7 +15,7 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="mt-6 bg-white sm:rounded-lg">
-        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |f| %>
+        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: {class: "space-y-6", data: {turbo: false}} do |f| %>
           <div>
             <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
             <div class="mt-1">
@@ -28,7 +28,7 @@
           </div>
 
           <div class="text-sm">
-            <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+            <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
               <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
             <% end %>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="mt-6 bg-white sm:rounded-lg">
-        <%= form_with model: resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |form| %>
+        <%= form_with model: resource, as: resource_name, url: registration_path(resource_name), html: {class: "space-y-6", data: {turbo: false}} do |form| %>
           <div>
             <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
             <div class="mt-1">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,7 +17,7 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="mt-6 bg-white sm:rounded-lg">
-        <%= form_for resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6", data: { turbo: false } } do |form| %>
+        <%= form_for resource, as: resource_name, url: session_path(resource_name), html: {class: "space-y-6", data: {turbo: false}} do |form| %>
           <div>
             <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
             <div class="mt-1">


### PR DESCRIPTION
This fixes https://github.com/joemasilotti/railsdevs.io/issues/35 and adds styling to the Forgot password, email confirmation and edit password pages.

Screenshots
<img width="990" alt="Screen Shot 2021-11-06 at 6 04 15 PM" src="https://user-images.githubusercontent.com/311936/140628510-7a8f5f20-4a33-4324-a9e0-c15f3a47c32b.png">
<img width="983" alt="Screen Shot 2021-11-06 at 6 04 22 PM" src="https://user-images.githubusercontent.com/311936/140628511-800daa43-d714-43e7-ad4d-7593a406ad15.png">
<img width="1003" alt="Screen Shot 2021-11-06 at 6 04 53 PM" src="https://user-images.githubusercontent.com/311936/140628512-df46eddd-19b4-4d0a-968b-e4332e6485ef.png">


