### PR TITLE
`Availability` concern

### DIFF
--- a/app/components/availability_component.html.erb
+++ b/app/components/availability_component.html.erb
@@ -1,0 +1,4 @@
+<span class="text-gray-900 text-sm <%= "font-medium" if @developer.available_now? %>">
+  <%= t(".#{@developer.availability_status}_html", date: date, date_in_words: date_in_words) %>
+</span>
+<%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mx-2" if @developer.available_now? %>

--- a/app/components/availability_component.rb
+++ b/app/components/availability_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AvailabilityComponent < ViewComponent::Base
   def initialize(developer:)
     @developer = developer

--- a/app/components/availability_component.rb
+++ b/app/components/availability_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AvailabilityComponent < ViewComponent::Base
+  def initialize(developer:)
+    @developer = developer
+  end
+
+  def date
+    @developer.available_on&.to_s(:db)
+  end
+
+  def date_in_words
+    return unless @developer.available?
+
+    time_ago_in_words(@developer.available_on)
+  end
+end

--- a/app/components/availability_component.rb
+++ b/app/components/availability_component.rb
@@ -10,7 +10,7 @@ class AvailabilityComponent < ViewComponent::Base
   end
 
   def date_in_words
-    return unless @developer.available?
+    return unless @developer.available_in_future?
 
     time_ago_in_words(@developer.available_on)
   end

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Availability
+  extend ActiveSupport::Concern
+
+  included do
+    enum availability_status: [:unspecified, :now, :in_future], _default: :unspecified, _prefix: :available
+  end
+
+  def available_on=(date)
+    super(date)
+    derive_availability_status
+  end
+
+  private
+
+  def derive_availability_status
+    status = if available_on.nil?
+      :unspecified
+    elsif available_on.future?
+      :in_future
+    else
+      :now
+    end
+
+    self.availability_status = status
+  end
+end

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Availability
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -3,6 +3,8 @@ module Availability
 
   included do
     enum availability_status: [:unspecified, :now, :in_future], _default: :unspecified, _prefix: :available
+
+    after_initialize :derive_availability_status
   end
 
   def available_on=(date)

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -12,6 +12,10 @@ class Developer < ApplicationRecord
   validates :cover_image, content_type: ["image/png", "image/jpg", "image/jpeg", "image/gif"],
     max_file_size: 10.megabytes
 
+  def available?
+    available_now? || availability_status == :in_future
+  end
+
   def available_now?
     availability_status == :available
   end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,4 +1,6 @@
 class Developer < ApplicationRecord
+  include Availability
+
   belongs_to :user
   has_one_attached :avatar
   has_one_attached :cover_image
@@ -11,20 +13,4 @@ class Developer < ApplicationRecord
     max_file_size: 2.megabytes
   validates :cover_image, content_type: ["image/png", "image/jpg", "image/jpeg", "image/gif"],
     max_file_size: 10.megabytes
-
-  def available?
-    available_now? || availability_status == :in_future
-  end
-
-  def available_now?
-    availability_status == :available
-  end
-
-  def availability_status
-    return :unspecified if available_on.nil?
-
-    return :in_future if available_on.future?
-
-    :available
-  end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -11,4 +11,16 @@ class Developer < ApplicationRecord
     max_file_size: 2.megabytes
   validates :cover_image, content_type: ["image/png", "image/jpg", "image/jpeg", "image/gif"],
     max_file_size: 10.megabytes
+
+  def available_now?
+    availability_status == :available
+  end
+
+  def availability_status
+    return :unspecified if available_on.nil?
+
+    return :in_future if available_on.future?
+
+    :available
+  end
 end

--- a/app/views/developers/_availability.html.erb
+++ b/app/views/developers/_availability.html.erb
@@ -1,0 +1,13 @@
+<% if developer.available_on.blank? %>
+  <span class="text-sm text-gray-900">
+    Currently unavailable
+  </span>
+<% elsif developer.available_on <= Date.current %>
+  <span class="font-medium text-sm text-gray-900">Available now</span>
+  <%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mx-2" %>
+<% else %>
+  <span class="text-sm text-gray-900">
+    Available in
+    <time datetime="<%= developer.available_on.to_s(:db) %>"><%= time_ago_in_words(developer.available_on) %></time>
+  </span>
+<% end %>

--- a/app/views/developers/_availability.html.erb
+++ b/app/views/developers/_availability.html.erb
@@ -1,5 +1,0 @@
-<span class="text-gray-900 text-sm <%= "font-medium" if developer.available_now? %>">
-  <%= t(".#{developer.availability_status}_html", date: developer.available_on&.to_s(:db),
-                                                 date_in_words: time_ago_in_words(developer.available_on)) %>
-</span>
-<%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mx-2" if developer.available_now? %>

--- a/app/views/developers/_availability.html.erb
+++ b/app/views/developers/_availability.html.erb
@@ -1,13 +1,5 @@
-<% if developer.available_on.blank? %>
-  <span class="text-sm text-gray-900">
-    Currently unavailable
-  </span>
-<% elsif developer.available_on <= Date.current %>
-  <span class="font-medium text-sm text-gray-900">Available now</span>
-  <%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mx-2" %>
-<% else %>
-  <span class="text-sm text-gray-900">
-    Available in
-    <time datetime="<%= developer.available_on.to_s(:db) %>"><%= time_ago_in_words(developer.available_on) %></time>
-  </span>
-<% end %>
+<span class="text-gray-900 text-sm <%= "font-medium" if developer.available_now? %>">
+  <%= t(".#{developer.availability_status}_html", date: developer.available_on&.to_s(:db),
+                                                 date_in_words: time_ago_in_words(developer.available_on)) %>
+</span>
+<%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mx-2" if developer.available_now? %>

--- a/app/views/developers/_developer.html.erb
+++ b/app/views/developers/_developer.html.erb
@@ -11,7 +11,7 @@
         </h2>
 
         <div class="hidden sm:inline-flex ml-auto flex-row-reverse items-center text-gray-400">
-          <%= render "developers/availability", developer: developer %>
+          <%= render AvailabilityComponent.new(developer: developer) %>
         </div>
       </div>
 

--- a/app/views/developers/_developer.html.erb
+++ b/app/views/developers/_developer.html.erb
@@ -11,19 +11,7 @@
         </h2>
 
         <div class="hidden sm:inline-flex ml-auto flex-row-reverse items-center text-gray-400">
-          <% if developer.available_on.blank? %>
-            <span class="text-sm text-gray-900">
-              Currently unavailable
-            </span>
-          <% elsif developer.available_on <= Date.current %>
-            <span class="font-medium text-sm text-gray-900">Available now</span>
-            <%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 mr-2" %>
-          <% else %>
-            <span class="text-sm text-gray-900">
-              Available in
-              <time datetime="<%= developer.available_on.to_s(:db) %>"><%= time_ago_in_words(developer.available_on) %></time>
-            </span>
-          <% end %>
+          <%= render "developers/availability", developer: developer %>
         </div>
       </div>
 

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -44,19 +44,7 @@
           Availability
         </dt>
         <dd class="flex mt-1 text-sm text-gray-900">
-          <% if @developer.available_on.blank? %>
-            <span class="text-sm text-gray-900">
-              Currently unavailable
-            </span>
-          <% elsif @developer.available_on <= Date.current %>
-            <span class="text-sm text-gray-900">Available now</span>
-            <%= inline_svg_tag "icons/solid/check_circle.svg", class: "h-5 w-5 text-green-400 ml-2" %>
-          <% else %>
-            <span class="text-sm text-gray-900">
-              Available in
-              <time datetime="<%= @developer.available_on.to_s(:db) %>"><%= time_ago_in_words(@developer.available_on) %></time>
-            </span>
-          <% end %>
+          <%= render "developers/availability", developer: @developer %>
         </dd>
       </div>
 

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -44,7 +44,7 @@
           Availability
         </dt>
         <dd class="flex mt-1 text-sm text-gray-900">
-          <%= render "developers/availability", developer: @developer %>
+          <%= render AvailabilityComponent.new(developer: @developer) %>
         </dd>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,9 @@ en:
   pundit:
     errors:
       unauthorized: You don't have access to that.
+
+  developers:
+    availability:
+      available_html: Available now
+      in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
+      unspecified_html: Currently unavailable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,8 +14,7 @@ en:
     errors:
       unauthorized: You don't have access to that.
 
-  developers:
-    availability:
-      available_html: Available now
-      in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
-      unspecified_html: Currently unavailable
+  availability_component:
+    available_html: Available now
+    in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
+    unspecified_html: Currently unavailable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,6 @@ en:
       unauthorized: You don't have access to that.
 
   availability_component:
-    available_html: Available now
+    now_html: Available now
     in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
     unspecified_html: Currently unavailable

--- a/test/components/availability_component_test.rb
+++ b/test/components/availability_component_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class AvailabilityComponentTest < ViewComponent::TestCase
+  setup do
+    @developer = developers(:one)
+  end
+
+  test "will show Currently unavailable when nil" do
+    @developer.available_on = nil
+    render_inline(AvailabilityComponent.new(developer: @developer))
+
+    assert_no_selector("svg")
+    assert_selector("span", text: "Currently unavailable")
+  end
+
+  test "will show Available now" do
+    @developer.available_on = Date.today - 3.weeks
+    render_inline(AvailabilityComponent.new(developer: @developer))
+
+    assert_selector("svg")
+    assert_selector("span", text: "Available now")
+  end
+
+  test "will show Available in with time to availability" do
+    @developer.available_on = Date.today + 2.months
+    render_inline(AvailabilityComponent.new(developer: @developer))
+
+    assert_no_selector("svg")
+    assert_selector("span", text: /Available\s*in\s*2 months/m)
+  end
+end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DeveloperTest < ActiveSupport::TestCase
+  setup do
+    @developer = developers(:one)
+  end
+
+  test "unspecified availability" do
+    @developer.available_on = nil
+
+    assert_equal :unspecified, @developer.availability_status
+    assert @developer.available_now? == false
+  end
+
+  test "available in a future date" do
+    @developer.available_on = Date.today + 2.weeks
+
+    assert_equal :in_future, @developer.availability_status
+    assert @developer.available_now? == false
+  end
+
+  test "available from a past date" do
+    @developer.available_on = Date.today - 3.weeks
+
+    assert_equal :available, @developer.availability_status
+    assert @developer.available_now? == true
+  end
+
+  test "available from today" do
+    @developer.available_on = Date.today
+
+    assert_equal :available, @developer.availability_status
+    assert @developer.available_now? == true
+  end
+end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class DeveloperTest < ActiveSupport::TestCase

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -10,28 +10,28 @@ class DeveloperTest < ActiveSupport::TestCase
   test "unspecified availability" do
     @developer.available_on = nil
 
-    assert_equal :unspecified, @developer.availability_status
-    assert @developer.available_now? == false
+    assert_equal "unspecified", @developer.availability_status
+    assert @developer.available_unspecified?
   end
 
   test "available in a future date" do
     @developer.available_on = Date.today + 2.weeks
 
-    assert_equal :in_future, @developer.availability_status
-    assert @developer.available_now? == false
+    assert_equal "in_future", @developer.availability_status
+    assert @developer.available_in_future?
   end
 
   test "available from a past date" do
     @developer.available_on = Date.today - 3.weeks
 
-    assert_equal :available, @developer.availability_status
-    assert @developer.available_now? == true
+    assert_equal "now", @developer.availability_status
+    assert @developer.available_now?
   end
 
   test "available from today" do
     @developer.available_on = Date.today
 
-    assert_equal :available, @developer.availability_status
-    assert @developer.available_now? == true
+    assert_equal "now", @developer.availability_status
+    assert @developer.available_now?
   end
 end


### PR DESCRIPTION
Introduce an `Availability` concern to encapsulate the logic to determine if a developer is available by utilising an `enum`.

This PR [originally](88cd5b242fdb991044cd41776c00e0461907130a) DRY'ed up the view logic by utilising a partial, however, the logic in #59 has been cherry-picked and adapted to work with the `Availability` concern.

*N.B:* This PR retains the previous styling / [wording](https://github.com/joemasilotti/railsdevs.io/pull/58/files#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R17-R20). i.e there are no changes to the UI from a user perspective.

---
<img width="1058" alt="Screenshot 2021-11-07 at 13 59 34" src="https://user-images.githubusercontent.com/1736807/140648146-4441ec71-6947-443d-b1ca-ba68eb14ab5a.png">


<img width="1043" alt="Screenshot 2021-11-07 at 13 59 27" src="https://user-images.githubusercontent.com/1736807/140648149-20d15ac8-7436-43be-a860-729110701205.png">


