### PR TITLE
Add basic twitter summary card.

### DIFF
--- a/app/components/developer_social_meta_tags_component.html.erb
+++ b/app/components/developer_social_meta_tags_component.html.erb
@@ -1,0 +1,13 @@
+<meta property="og:type" content="website">
+<meta property="og:title" content="<%= @developer.hero %>">
+<meta property="og:description" content="<%= @developer.bio %>">
+<meta property="og:url" content="<%= developer_url(@developer) %>">
+
+<% if @developer.avatar.present? %>
+  <meta property="og:image" content="<%= rails_blob_url(@developer.avatar) %>">
+<% end %>
+
+<meta name="twitter:card" content="summary">
+<% if @developer.twitter.present? %>
+  <meta name="twitter:site" content="@<%= @developer.twitter %>">
+<% end %>

--- a/app/components/developer_social_meta_tags_component.rb
+++ b/app/components/developer_social_meta_tags_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class DeveloperSocialMetaTagsComponent < ViewComponent::Base
   def initialize(developer:)
     @developer = developer

--- a/app/components/developer_social_meta_tags_component.rb
+++ b/app/components/developer_social_meta_tags_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DeveloperSocialMetaTagsComponent < ViewComponent::Base
+  def initialize(developer:)
+    @developer = developer
+  end
+end

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,3 +1,17 @@
+<% content_for :social_meta do %>
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="<%= @developer.hero %>">
+  <meta property="og:description" content="<%= @developer.bio %>">
+  <meta property="og:url" content="<%= developer_url(@developer) %>">
+
+  <% if @developer.avatar.present? %>
+    <meta property="og:image" content="<%= rails_blob_url(@developer.avatar) %>">
+  <% end %>
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@<%= @developer.twitter %>">
+<% end %>
+
 <div class="pb-8">
   <div class="w-full aspect-w-4 aspect-h-1">
     <% if @developer.cover_image.attached? %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,15 +1,5 @@
 <% content_for :social_meta do %>
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="<%= @developer.hero %>">
-  <meta property="og:description" content="<%= @developer.bio %>">
-  <meta property="og:url" content="<%= developer_url(@developer) %>">
-
-  <% if @developer.avatar.present? %>
-    <meta property="og:image" content="<%= rails_blob_url(@developer.avatar) %>">
-  <% end %>
-
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@<%= @developer.twitter %>">
+  <%= render DeveloperSocialMetaTagsComponent.new(developer: @developer) %>
 <% end %>
 
 <div class="pb-8">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,8 @@
 
     <%= analytics_tag %>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+
+    <%= content_for :social_meta %>
   </head>
 
   <body class="h-full">

--- a/test/components/developer_social_meta_tags_component_test.rb
+++ b/test/components/developer_social_meta_tags_component_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class DeveloperSocialMetaTagsComponentTest < ViewComponent::TestCase
+  def test_always_includes_basic_tags
+    developer = Developer.new(
+      id: 123,
+      hero: "hero text",
+      bio: "bio text"
+    )
+    render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
+
+    assert_meta '[property="og:title"][content="hero text"]'
+    assert_meta '[property="og:description"][content="bio text"]'
+    assert_meta '[property="og:url"][content="http://test.host/developers/123"]'
+  end
+
+  def test_excludes_special_tags_when_not_present
+    developer = Developer.new(id: 123)
+    render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
+
+    assert_meta '[property="og:image"]', count: 0
+    assert_meta '[name="twitter:site"]', count: 0
+  end
+
+  def test_includes_image_when_present
+    developer = Developer.new(id: 123)
+    developer.build_avatar_blob(filename: "avatar.jpg")
+    render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
+
+    assert_meta '[property="og:image"][content$="/avatar.jpg"]'
+  end
+
+  def test_includes_twitter_when_present
+    developer = Developer.new(id: 123, twitter: "me")
+    render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
+
+    assert_meta '[name="twitter:site"][content="@me"]'
+  end
+
+  def assert_meta(attributes_selector, count: 1)
+    assert_selector "meta#{attributes_selector}", visible: false, count: count
+  end
+end

--- a/test/components/developer_social_meta_tags_component_test.rb
+++ b/test/components/developer_social_meta_tags_component_test.rb
@@ -9,17 +9,17 @@ class DeveloperSocialMetaTagsComponentTest < ViewComponent::TestCase
     )
     render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
 
-    assert_meta '[property="og:title"][content="hero text"]'
-    assert_meta '[property="og:description"][content="bio text"]'
-    assert_meta '[property="og:url"][content="http://test.host/developers/123"]'
+    assert_meta "[property='og:title'][content='hero text']"
+    assert_meta "[property='og:description'][content='bio text']"
+    assert_meta "[property='og:url'][content='http://test.host/developers/123']"
   end
 
   def test_excludes_special_tags_when_not_present
     developer = Developer.new(id: 123)
     render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
 
-    assert_meta '[property="og:image"]', count: 0
-    assert_meta '[name="twitter:site"]', count: 0
+    assert_meta "[property='og:image']", count: 0
+    assert_meta "[name='twitter:site']", count: 0
   end
 
   def test_includes_image_when_present
@@ -27,14 +27,14 @@ class DeveloperSocialMetaTagsComponentTest < ViewComponent::TestCase
     developer.build_avatar_blob(filename: "avatar.jpg")
     render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
 
-    assert_meta '[property="og:image"][content$="/avatar.jpg"]'
+    assert_meta "[property='og:image'][content$='/avatar.jpg']"
   end
 
   def test_includes_twitter_when_present
     developer = Developer.new(id: 123, twitter: "me")
     render_inline(DeveloperSocialMetaTagsComponent.new(developer: developer))
 
-    assert_meta '[name="twitter:site"][content="@me"]'
+    assert_meta "[name='twitter:site'][content='@me']"
   end
 
   def assert_meta(attributes_selector, count: 1)


### PR DESCRIPTION
This was a very quick take just to get something out there. Happy to make any changes desired.

Please let me know if you want any tests in particular.

### Validator previews

#### No avatar
![image](https://user-images.githubusercontent.com/1972800/140766497-3d6fe3eb-d1b1-4155-86df-18dd62cda79d.png)

#### With avatar
![image](https://user-images.githubusercontent.com/1972800/140766598-005930b5-6a9f-4a69-b663-2ee8e63346ad.png)


Note: Twitter inherits og:title and og:description so there's no need to redefine them just for twitter.

/cc #37 