### PR TITLE
Message the user's confirmed email

### DIFF
--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -49,7 +49,6 @@ class DevelopersController < ApplicationController
   def developer_params
     params.require(:developer).permit(
       :name,
-      :email,
       :available_on,
       :hero,
       :bio,

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,7 +6,6 @@ class Developer < ApplicationRecord
   has_one_attached :cover_image
 
   validates :name, presence: true
-  validates :email, presence: true
   validates :hero, presence: true
   validates :bio, presence: true
   validates :avatar, content_type: ["image/png", "image/jpg", "image/jpeg"],

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -21,10 +21,13 @@
         </div>
 
         <div class="sm:col-start-1 sm:col-end-4">
-          <%= form.label :email, "Email address", class: "block text-sm font-medium text-gray-700" %>
+          <%= label_tag :email, "Email address", class: "block text-sm font-medium text-gray-700" %>
           <div class="mt-1">
-            <%= form.email_field :email, autocomplete: "email", class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md" %>
+            <%= email_field_tag "email", :email, autocomplete: "email", value: developer.user.email, disabled: true, class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md" %>
           </div>
+          <p class="mt-2 text-sm text-gray-500">
+            Your verified account is used.
+          </p>
         </div>
 
         <div class="sm:col-span-6">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -22,7 +22,7 @@
 
         <% if user_signed_in? %>
           <div class="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
-            <%= render ButtonLinkComponent.new("mailto:#{@developer.email}", icon: "mail") do %>
+            <%= render ButtonLinkComponent.new("mailto:#{@developer.user.email}", icon: "mail") do %>
               Message
             <% end %>
           </div>

--- a/db/migrate/20211108230111_deprecate_developers_email.rb
+++ b/db/migrate/20211108230111_deprecate_developers_email.rb
@@ -1,0 +1,6 @@
+class DeprecateDevelopersEmail < ActiveRecord::Migration[7.0]
+  def change
+    # Non-null for now, but will be removed later.
+    change_column_null :developers, :email, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_07_024057) do
+ActiveRecord::Schema.define(version: 2021_11_08_230111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_11_07_024057) do
 
   create_table "developers", force: :cascade do |t|
     t.string "name", null: false
-    t.string "email", null: false
+    t.string "email"
     t.date "available_on"
     t.string "hero", null: false
     t.text "bio", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,6 @@ end
 Developer.create!(
   user: create_user!("Dennis"),
   name: "Dennis Ritchie",
-  email: "dennis@example.com",
   available_on: Date.new(2021, 1, 1),
   hero: "Creator of C",
   bio: "An American computer scientist. Created the C programming language and, with long-time colleague Ken Thompson, the Unix operating system and B programming language.",
@@ -22,7 +21,6 @@ Developer.create!(
 Developer.create!(
   user: create_user!("Bjarne"),
   name: "Bjarne Stroustrup",
-  email: "bjarne@example.com",
   available_on: Date.new(2022, 1, 1),
   hero: "Creator of C++",
   bio: "A Danish computer scientist, most notable for the creation and development of the C++ programming language. A visiting professor at Columbia University, and works at Morgan Stanley as a Managing Director in New York.",
@@ -34,7 +32,6 @@ Developer.create!(
 Developer.create!(
   user: create_user!("Ada"),
   name: "Ada Lovelace",
-  email: "ada@example.com",
   available_on: Date.new(2021, 1, 1),
   hero: "First computer programmer",
   bio: "An English mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical general-purpose computer, the Analytical Engine.",

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -1,7 +1,6 @@
 one:
   user: with_profile_one
   name: Developer One
-  email: one@example.com
   available_on: <%= Date.new(2021, 1, 1) %>
   hero: First developer
   bio: I am the first developer
@@ -9,7 +8,6 @@ one:
 two:
   user: with_profile_two
   name: Developer Two
-  email: two@example.com
   available_on: <%= Date.new(2022, 2, 2) %>
   hero: Second developer
   bio: I am the second developer

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -12,18 +12,18 @@ class DevelopersTest < ActionDispatch::IntegrationTest
   end
 
   test "can see send message button if signed in" do
-    sign_in users(:with_profile_one)
-    developer = developers(:one)
+    user = users(:with_profile_one)
+    sign_in user
 
     get developer_path(developers(:one))
 
-    assert_select "a[href=?]", "mailto:#{developer.email}"
+    assert_select "a[href=?]", "mailto:#{user.email}"
   end
 
   test "send message button is hidden if not signed in" do
     developer = developers(:one)
     get developer_path(developers(:one))
-    assert_select "a[href=?]", "mailto:#{developer.email}", false
+    assert_select "a[href=?]", "mailto:#{developer.user.email}", false
   end
 
   test "cannot create new proflie if already has one" do
@@ -33,7 +33,6 @@ class DevelopersTest < ActionDispatch::IntegrationTest
       post developers_path, params: {
         developer: {
           name: "Developer",
-          email: "dev@example.com",
           available_on: Date.yesterday,
           hero: "A developer",
           bio: "I develop."
@@ -125,7 +124,6 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     {
       developer: {
         name: "Developer",
-        email: "dev@example.com",
         available_on: Date.yesterday,
         hero: "A developer",
         bio: "I develop."


### PR DESCRIPTION
Before, someone could put any email in when filling out the Developer form. Now, the only way to change that is to change your account's email address.

In the future, this might change to allow enabling new emails. But for now this works well enough.

`developers.email` is now deprecated, but the data remains in case we need to bring it back in the future.