### PR TITLE
Don't show add your profile button when profile is already there

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,8 @@ class User < ApplicationRecord
   has_many :notifications, as: :recipient
 
   scope :admin, -> { where(admin: true) }
+
+  def has_developer_profile?
+    developer&.persisted?
+  end
 end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -17,9 +17,11 @@
     <h3 class="text-lg leading-6 font-medium text-gray-900">
       Developers available now
     </h3>
-    <div class="mt-3 sm:mt-0 sm:ml-4">
-      <%= link_to "Add your profile", new_developer_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
-    </div>
+    <% unless current_user&.has_developer_profile? %>
+      <div class="mt-3 sm:mt-0 sm:ml-4">
+        <%= link_to "Add your profile", new_developer_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+      </div>
+    <% end %>
   </div>
 
   <ul role="list" class="space-y-8 bg-gray-100">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,7 +31,7 @@
               <%= link_to "Sign in", new_user_session_path, class: "text-base font-medium text-white hover:text-gray-300" %>
             <% end %>
 
-            <% if current_user&.developer&.persisted? %>
+            <% if current_user&.has_developer_profile? %>
               <%= link_to "Edit your profile", edit_developer_path(current_user.developer), class: "inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700" %>
             <% else %>
               <%= link_to "Add your profile", new_developer_path, class: "inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700" %>
@@ -66,7 +66,7 @@
           </div>
         <% end %>
 
-        <% if current_user&.developer&.persisted? %>
+        <% if current_user&.has_developer_profile? %>
           <div class="mt-6 px-5">
             <%= link_to "Edit your profile", edit_developer_path(current_user.developer), class: "block text-center w-full py-3 px-4 rounded-md shadow bg-gray-600 text-white font-medium hover:bg-gray-700" %>
           </div>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "has developer profile?" do
+    user = users(:without_profile)
+
+    assert_not user.has_developer_profile?
+
+    user = users(:with_available_profile)
+
+    assert user.has_developer_profile?
+  end
+end


### PR DESCRIPTION
- currently, there is add your profile button shown even when the profile is added

- also added an instance method has_developer_profile? which can be used across views


- [x] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project `bundle exec standardrb --fix`

