### PR TITLE
[bugfix] Respect new lines on the developers/show page

### DIFF
--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -93,7 +93,7 @@
           Bio
         </dt>
         <dd class="mt-1 text-sm text-gray-900 space-y-5">
-          <p><%= @developer.bio %></p>
+          <%= simple_format @developer.bio %>
         </dd>
       </div>
     </dl>


### PR DESCRIPTION
## Purpose

The developers/show page was not respecting new lines in the developer's bio text. I believe the intent is to keep this field relatively short, but I found myself wanting to split my bio into 2 small paragraphs. Perhaps discussing and implementing a character limit is a good next step for a separate PR.

### Before Screenshot
![image](https://user-images.githubusercontent.com/300131/141862959-d50bb489-2397-4085-abfe-4705a15ee064.png)


### After Screenshot
![image](https://user-images.githubusercontent.com/300131/141862929-44dfee4c-19f4-4c38-a305-0f5e1bfec870.png)


## Approach
Uses the `simple_format` method to output sanitized HTML that respects new lines

https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format

### Testing
I do not believe this warrants any testing since it's a one line fix that uses a pretty standard `ActionView` helper