### PR TITLE
Fix main content area on developers/show from butting up against site footer

### DIFF
--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -2,7 +2,7 @@
   <%= render DeveloperOpenGraphTagsComponent.new(developer: @developer) %>
 <% end %>
 
-<div class="mt-0 lg:mt-16 pb-8 bg-white shadow lg:rounded-lg overflow-hidden">
+<div class="mt-0 mb-16 lg:mt-16 pb-8 bg-white shadow lg:rounded-lg overflow-hidden">
   <div class="w-full aspect-w-4 aspect-h-1">
     <% if @developer.cover_image.attached? %>
       <%= image_tag @developer.cover_image, class: "w-full h-full object-cover" %>


### PR DESCRIPTION
## Purpose

The main content area on the developers/show page was butting right up against the footer. This PR fixes that.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/300131/141865656-d0472723-7361-47c9-9619-711cc259183d.png)

After(desktop):
![image](https://user-images.githubusercontent.com/300131/141865631-92775cba-ec77-44d7-959f-030b48e232f2.png)

After(mobile):
![image](https://user-images.githubusercontent.com/300131/141871411-d6200216-3a2b-4400-ae76-cdb6ce4fd31f.png)



## Approach

Add `mb-16` to the outer most div on developers/show page. `mb-16` seemed to be the standard elsewhere across the site, so I rolled with that.