### PR TITLE
Adds slug to developers table for prettier URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.0.2"
 gem "rails", github: "rails/rails", branch: "main"
 
 gem "cssbundling-rails", "~> 0.2"
+gem "friendly_id", "~> 5.4.0"
 gem "hotwire-rails", "~> 0.1"
 gem "jsbundling-rails", "~> 0.1"
 gem "pg", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
     honeybadger (4.9.0)
@@ -305,6 +307,7 @@ DEPENDENCIES
   classy-yaml (~> 0.6)
   cssbundling-rails (~> 0.2)
   devise!
+  friendly_id (~> 5.4.0)
   honeybadger (~> 4.0)
   hotwire-rails (~> 0.1)
   inline_svg (~> 1.7)

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -27,12 +27,12 @@ class DevelopersController < ApplicationController
   end
 
   def edit
-    @developer = Developer.find(params[:id])
+    @developer = Developer.friendly.find(params[:id])
     authorize @developer
   end
 
   def update
-    @developer = Developer.find(params[:id])
+    @developer = Developer.friendly.find(params[:id])
     authorize @developer
 
     if @developer.update(developer_params)
@@ -43,7 +43,7 @@ class DevelopersController < ApplicationController
   end
 
   def show
-    @developer = Developer.find(params[:id])
+    @developer = Developer.friendly.find(params[:id])
   end
 
   private

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,9 +1,12 @@
 class Developer < ApplicationRecord
+  extend FriendlyId
   include Availability
 
   belongs_to :user
   has_one_attached :avatar
   has_one_attached :cover_image
+
+  friendly_id :name, use: :slugged
 
   validates :name, presence: true
   validates :hero, presence: true

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w[new edit index session login logout users admin
+    stylesheets assets javascripts images]
+
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20211115233646_add_slug_to_developers.rb
+++ b/db/migrate/20211115233646_add_slug_to_developers.rb
@@ -1,0 +1,8 @@
+class AddSlugToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :slug, :string
+    add_index :developers, :slug, unique: true
+
+    Developer.find_each(&:save)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_08_230111) do
+ActiveRecord::Schema.define(version: 2021_11_15_233646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,8 @@ ActiveRecord::Schema.define(version: 2021_11_08_230111) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
     t.string "linkedin"
+    t.string "slug"
+    t.index ["slug"], name: "index_developers_on_slug", unique: true
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -62,7 +62,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
         name: "New Name"
       }
     }
-    assert_redirected_to developer_path(developer)
+    assert_redirected_to developer_path(developer.reload.slug)
     follow_redirect!
 
     assert_equal "New Name", developer.reload.name
@@ -92,7 +92,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
         name: "New Name"
       }
     }
-    assert_redirected_to developer_path(developer)
+    assert_redirected_to developer_path(developer.reload.slug)
     assert_equal "New Name", developer.reload.name
   end
 


### PR DESCRIPTION
## Purpose
This PR adds slugs to the developers table & URLs that are based on the `name` column. This makes URL's a little more human friendly, so the user sees something like `/developers/casey-jenks` instead of `/developers/231`.

## Approach
The `friendly_id` gem made this pretty trivial. 

## Open Questions
We need to populate the `slug` field for all existing developers. I added this into the migration and figure we could probably get away with it since the table is still so tiny:

```
Developer.find_each(&:save)
```

If you would rather this be pulled into a rake task, or even just run this from the console post deployment, let me know and we can adjust.

## Screenshots
_Before_:
![image](https://user-images.githubusercontent.com/300131/141871273-210b23cc-8126-465d-a742-7d3fbc19131e.png)


_After_:
![image](https://user-images.githubusercontent.com/300131/141871233-23eb3d00-efd7-4765-9865-4a58adab9038.png)
